### PR TITLE
Working directory error

### DIFF
--- a/src/PackageResolver/ComposerStrategy.php
+++ b/src/PackageResolver/ComposerStrategy.php
@@ -29,6 +29,11 @@ class ComposerStrategy implements PackageResolverStrategy
         return $packages;
     }
 
+    public function resolveRootPath(): string
+    {
+        return \dirname($this->resolveVendorPath());
+    }
+
     public function resolveVendorPath(): string
     {
         return $this->composer->getConfig()->get('vendor-dir');

--- a/src/PackageResolver/LockReaderStrategy.php
+++ b/src/PackageResolver/LockReaderStrategy.php
@@ -12,6 +12,11 @@ class LockReaderStrategy implements PackageResolverStrategy
     {
     }
 
+    public function resolveRootPath(): string
+    {
+        return $this->rootDirectory;
+    }
+
     public function resolveVendorPath(): string
     {
         return implode(DIRECTORY_SEPARATOR, [$this->rootDirectory, 'vendor']);

--- a/src/PackageResolverStrategy.php
+++ b/src/PackageResolverStrategy.php
@@ -4,6 +4,7 @@ namespace Sansec\Integrity;
 
 interface PackageResolverStrategy
 {
-    public function resolveVendorPath(): string;
     public function resolvePackages(): array;
+    public function resolveRootPath(): string;
+    public function resolveVendorPath(): string;
 }

--- a/src/PackageSubmitter.php
+++ b/src/PackageSubmitter.php
@@ -46,7 +46,9 @@ class PackageSubmitter
     private function getVendorState(array $packages): array
     {
         return [
-            'id'        => $this->hasher->generateInstallIdHash(getcwd()),
+            'id'        => $this->hasher->generateInstallIdHash(
+                $this->packageResolverStrategy->resolveRootPath()
+            ),
             'hash_type' => 0, // xxh64
             'origin'    => 1,
             'pkg'       => array_map(


### PR DESCRIPTION
While working to implement the new interface created in #14, I encountered an error when the working directory is not the same as the Composer root directory. This pull request replaces the call to `\getcwd()` with a new resolver method to retrieve the correct directory.